### PR TITLE
Refactor reader into modular call functions

### DIFF
--- a/agents/reader.py
+++ b/agents/reader.py
@@ -17,14 +17,14 @@ from call_functions import pdf_reader
 
 
 #       === SETUP ===
+spinner = Halo(text="Loading", spinner="dots")
+
 DATA_DIR = "./data"
 files = os.listdir(DATA_DIR)
 terminal_menu = TerminalMenu(files)
 selected_index = terminal_menu.show()
 pdf_file = DATA_DIR + "/" + files[selected_index]
-print(f"{pdf_file} selected.")
-
-spinner = Halo(text="Loading", spinner="dots")
+print(f"[{pdf_file}] selected.")
 
 print("Available tools:")
 pp(pdf_reader.tool_map)
@@ -35,32 +35,40 @@ chat_agent = ChatOllama(
     reasoning=True,
 ).bind_tools(pdf_reader.tools)
 
+spinner.start('initializing vector store...')
 asyncio.run(pdf_reader.db_init(pdf_file))
+spinner.stop()
 print("Vector store initialized.")
 
 messages = [
-    SystemMessage(content="A pdf file is provided. You can use the tools to read and query the PDF file."),
+    SystemMessage(content='\n'.join([
+        "A pdf file is provided. You can use the tools provided to read and query the PDF file.",
+        "user's locale is ko-KR, so you should answer in Korean.",
+    ])),
     HumanMessage(content="what is the main topic of the PDF?"),
 ]
 
 
 def main() -> None:
-    spinner.start()
+    spinner.start('asking AI...')
     ai_msg = chat_agent.invoke(messages)
     spinner.stop()
 
-    print("=" * 10)
+    print("=" * 25, '\nAI Response:\n')
     pp(ai_msg.tool_calls)
 
+    spinner.start('executing tool calls...')
     for tool_call in ai_msg.tool_calls:
         selected_tool = pdf_reader.tool_map[tool_call["name"].lower()]
         tool_output = selected_tool.invoke(tool_call["args"])
         messages.append(ToolMessage(content=str(tool_output), tool_call_id=tool_call["id"]))
+    spinner.stop()
 
-    spinner.start()
+    spinner.start('asking AI...')
     ai_msg2 = chat_agent.invoke(messages)
     spinner.stop()
 
+    print("=" * 25, '\nAI Response:\n')
     pp(ai_msg2.content)
 
 

--- a/agents/reader.py
+++ b/agents/reader.py
@@ -1,9 +1,6 @@
 # Langchain
 from langchain_ollama import ChatOllama
-from langchain_core.messages import BaseMessage, AIMessage, ToolMessage
-from langchain_core.tools import tool
-from langchain_core.vectorstores import InMemoryVectorStore
-from langchain_core.documents import Document
+from langchain_core.messages import ToolMessage, SystemMessage, HumanMessage
 
 # system/default
 import os
@@ -18,13 +15,6 @@ from simple_term_menu import TerminalMenu
 from utils.get_env import OLLAMA_SERVER_URL
 from call_functions import pdf_reader
 
-@tool
-def query_pdf(query: str) -> list[Document] | None:
-    """
-    returns the most relevant text from the PDF file based on the query.
-    """
-    docs = vector_store.similarity_search(query)
-    return docs if docs else None
 
 #       === SETUP ===
 DATA_DIR = "./data"
@@ -34,54 +24,46 @@ selected_index = terminal_menu.show()
 pdf_file = DATA_DIR + "/" + files[selected_index]
 print(f"{pdf_file} selected.")
 
-spinner = Halo(text='Loading', spinner='dots')
-
-tools = [query_pdf]
-tool_map = {t.name: t for t in tools}
+spinner = Halo(text="Loading", spinner="dots")
 
 print("Available tools:")
-pp(tool_map)
+pp(pdf_reader.tool_map)
 
 chat_agent = ChatOllama(
     base_url=OLLAMA_SERVER_URL,
-    model='qwen3:14b',
+    model="qwen3:14b",
     reasoning=True,
-).bind_tools(tools)
+).bind_tools(pdf_reader.tools)
 
-vector_store = asyncio.run(
-    pdf_reader.db_init(pdf_file)
-)
+asyncio.run(pdf_reader.db_init(pdf_file))
 print("Vector store initialized.")
-
-##############################################################
-
-from langchain_core.messages import SystemMessage, HumanMessage
 
 messages = [
     SystemMessage(content="A pdf file is provided. You can use the tools to read and query the PDF file."),
     HumanMessage(content="what is the main topic of the PDF?"),
 ]
 
-def main():
+
+def main() -> None:
     spinner.start()
     ai_msg = chat_agent.invoke(messages)
     spinner.stop()
 
-    print("="*10)
+    print("=" * 10)
     pp(ai_msg.tool_calls)
 
     for tool_call in ai_msg.tool_calls:
-        tool_args = tool_call["args"]
-        tool_args.pop("self", None)  # remove 'self' from args
-        selected_tool = tool_map[tool_call["name"].lower()]
-        tool_output = selected_tool.invoke(input=tool_args)
+        selected_tool = pdf_reader.tool_map[tool_call["name"].lower()]
+        tool_output = selected_tool.invoke(tool_call["args"])
         messages.append(ToolMessage(content=str(tool_output), tool_call_id=tool_call["id"]))
 
     spinner.start()
-    ai_msg2 = chat_agent.invoke(input=messages)
+    ai_msg2 = chat_agent.invoke(messages)
     spinner.stop()
 
     pp(ai_msg2.content)
 
+
 if __name__ == "__main__":
     main()
+

--- a/call_functions/__init__.py
+++ b/call_functions/__init__.py
@@ -1,1 +1,4 @@
-from . import *
+from . import pdf_reader, test
+
+__all__ = ["pdf_reader", "test"]
+

--- a/call_functions/pdf_reader.py
+++ b/call_functions/pdf_reader.py
@@ -7,6 +7,8 @@ from langchain_core.vectorstores import InMemoryVectorStore
 
 from utils.get_env import OLLAMA_SERVER_URL
 
+import warnings
+
 
 vector_store: InMemoryVectorStore | None = None
 
@@ -27,6 +29,7 @@ async def db_init(pdf_file_path: str, embed_model: str = "llama3.1:8b") -> None:
 def query_pdf(query: str) -> list[Document] | None:
     """Returns the most relevant text from the PDF file based on the query."""
     if vector_store is None:
+        warnings.warn("Vector store is not initialized.")
         return None
     docs = vector_store.similarity_search(query)
     return docs if docs else None


### PR DESCRIPTION
## Summary
- move PDF query logic into `call_functions/pdf_reader` with exported tools
- simplify `agents/reader` to use shared pdf_reader utilities
- expose call functions modules via `call_functions.__all__`

## Testing
- `python -m py_compile agents/reader.py call_functions/pdf_reader.py call_functions/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689084224a248330b30cc126463fcd6c